### PR TITLE
Fix inventory auto-refresh from GPT updates

### DIFF
--- a/merged_app_v2.py
+++ b/merged_app_v2.py
@@ -362,10 +362,11 @@ def emit_inventory(source=None):
     logger.info(f"Aggregated {len(agg)} unique items")
     
     try:
-        socketio.emit("inventory_update",
-                      {"inventory": agg,
-                       "timestamp": time.time(),
-                       "source": source})
+        socketio.emit(
+            "inventory_update",
+            {"inventory": agg, "timestamp": time.time(), "source": source},
+            broadcast=True,
+        )
         end_time = time.time()
         logger.info(f"Inventory emit completed in {end_time - start_time:.3f} seconds")
     except Exception as e:

--- a/templates/index.html
+++ b/templates/index.html
@@ -645,6 +645,12 @@
             connectionStatus.textContent = 'Connection Error';
             connectionStatus.className = 'disconnected';
         });
+
+        // Respond when server requests a fresh state
+        socket.on('request_fresh_state', () => {
+            console.log('Server requested fresh inventory');
+            socket.emit('request_fresh_inventory');
+        });
         
         // Add periodic refresh mechanism
         let refreshInterval;


### PR DESCRIPTION
## Summary
- broadcast inventory updates to all Socket.IO clients
- handle server `request_fresh_state` events on the client

## Testing
- `python3 -m py_compile merged_app_v2.py`

------
https://chatgpt.com/codex/tasks/task_e_6844cf360338832697985c87ee160d7b